### PR TITLE
Added makefile to install shup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.POSIX:
+
+prefix = /usr/local
+name = shup
+
+all:
+	@echo "all target"
+
+install:
+	@echo "Installing ${name}..."
+	install -m 555 ${name} $(DESTDIR)$(prefix)/bin/
+	@echo "done!"
+
+clean:
+	@echo "Cleaning ${name}"
+
+distclean: clean
+
+uninstall:
+	@echo "Uninstalling ${name}..."
+	rm -f $(DESTDIR)$(prefix)/bin/${name}
+	@echo "done!"
+
+.PHONY: all install clean distclean uninstall

--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@ Simple HTML parser in shell.
 	* POSIX shell
 	* sed
 
+## Installation
+    
+To install `shup` you can edit the `Makefile` to match your local setup (`shup` is installed into the `/usr/local/bin` by default).
+
+Afterwards enter the following command to install `shup`:
+
+```sh
+sudo make install
+```
+
+To uninstall `shup`, just run:
+
+```sh
+sudo make uninstall
+```
+
 ## Usage
 
 	


### PR DESCRIPTION
## Description

Added `Makefile` to make it easier to install `shup`.

Now we can install `shup` with: `sudo make install`.

I also added a **Installation** section to `README.md` to help users to understand how to install and uninstall the package.

## Related issue

#2

## Motivation and context

With the `Makefile` we can easily install and uninstall the package, and it will be helpful when packaging to Debian.

